### PR TITLE
fix: navbar about hover showing random text

### DIFF
--- a/client/src/components/LandingPage/Navbar.jsx
+++ b/client/src/components/LandingPage/Navbar.jsx
@@ -88,7 +88,6 @@ const go = (path) => {
           <li className="about-link">
             <Link to="/about">About</Link>
             <span className="material-symbols-outlined dropdown">
-              keyboard_arrow_down
             </span>
             <ul className="dropdown">
               <li>


### PR DESCRIPTION
- removed keyboard_arrow_down in the dropdown section