### PR TITLE
feat: created confirmation email page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import About from "./pages/About";
 import Search from "./pages/Search";
 import Login from "./pages/Login";
 import SignUp from "./pages/SignUp";
+import ConfirmEmail from "./pages/ConfirmEmail";
 import Profile from "./pages/Profile";
 import Explore from "./pages/Explore";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
@@ -42,6 +43,7 @@ const App = () => {
         <Route path="/search" element={<Search />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<SignUp />} />
+        <Route path="/confirm" element={<ConfirmEmail />} />
         <Route path="/profile" element={<Profile />} />
         <Route path="/explore" element={<Explore />} />
         <Route path="/PrivacyPolicy" element={<PrivacyPolicy />} />

--- a/client/src/components/LandingPage/Footer.jsx
+++ b/client/src/components/LandingPage/Footer.jsx
@@ -5,7 +5,7 @@ import FavoriteIcon from '@mui/icons-material/Favorite';
 
 const Footer = () => {
     const location = useLocation();
-    const hiddenRoute = ["/login", "/signup"];
+    const hiddenRoute = ["/login", "/signup", "/confirm"];
 
     if (hiddenRoute.includes(location.pathname)) {
         return null;

--- a/client/src/components/LandingPage/Navbar.jsx
+++ b/client/src/components/LandingPage/Navbar.jsx
@@ -67,10 +67,10 @@ const go = (path) => {
   };
 
   //Hide the navigation bar on signup and login
-  if (location.pathname === "/login" || location.pathname === "/signup") {
+  if (location.pathname === "/login" || location.pathname === "/signup" || location.pathname === "/confirm") {
     return null;
   }
-
+  
   // Secure navigation to profile
   const handleProfileClick = () => {
     if (localStorage.getItem("token")) {

--- a/client/src/pages/ConfirmEmail.jsx
+++ b/client/src/pages/ConfirmEmail.jsx
@@ -1,0 +1,101 @@
+import React, { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import {confirmEmail } from "../api";
+import confirmationImage from "../assets/confirmation.svg";
+import { TextField, Button } from "@mui/material";
+
+const ConfirmEmail = () => {
+    const location = useLocation();
+    const [confirmCode, setConfirmCode] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [errors, setErrors] = useState({});
+
+    const email = location.state?.email || "";
+    
+    const handleConfirm = async (e) => {
+        e.preventDefault();
+            setLoading(true);
+            try {
+              const response = await confirmEmail({ email, code: confirmCode });
+              // alert(response.data.message);
+              navigate("/login");
+            } catch (err) {
+              // alert("Confirmation failed: " + (err.response?.data?.error || "Unknown error"));
+              setErrors((prevErrors) => ({
+                ...prevErrors,
+                confirm: "Invalid confirmation code",
+              }));
+            }
+            setLoading(false);
+    };
+
+    return (
+        <div className="signup-page">
+            <div className="signup-form">
+              <h1>Confirm Your Email</h1>
+            <img src={confirmationImage} alt = "Girl holding a phone with a checkmark icon indicating email confirmation." className="confirmation-svg"></img>
+            <form onSubmit={handleConfirm} noValidate>
+              <div>
+                <TextField
+                  label="Email"
+                  type="email"
+                  variant="outlined"
+                  fullWidth
+                  value={email}
+                  disabled
+                  margin="normal"
+                  slotProps={{
+                    root: {
+                      className: 'form-textfield-root',
+                    },
+                    inputLabel: {
+                      className: 'form-textfield-label',
+                    },
+                    input: {
+                      className:'form-textfield-input',
+                    },
+                  }}
+                />
+              </div>
+              <div>
+                <TextField
+                  label="Confirmation Code"
+                  variant="outlined"
+                  fullWidth
+                  value={confirmCode}
+                  onChange={(e) => setConfirmCode(e.target.value)}
+                //   error = {!!errors.confirm}
+                //   helperText={errors.confirm}
+                  required
+                  margin="normal"
+                  slotProps={{
+                    root: {
+                      className: 'form-textfield-root',
+                    },
+                    inputLabel: {
+                      className: 'form-textfield-label',
+                    },
+                    input: {
+                      className:'form-textfield-input',
+                    },
+                  }}
+            />
+              </div>
+              <Button
+                type="submit"
+                variant="contained"
+                color="primary"
+                fullWidth
+                className = "signup"
+                disabled={loading}
+              >
+                {loading ? "Confirming..." : "Confirm Email"}
+              </Button>
+            </form>
+            </div>
+            <div className="signup-image"></div>
+        </div>
+    );
+}
+
+export default ConfirmEmail;

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -33,6 +33,7 @@ const Login = () => {
 
     try {
       const response = await login({ email, password });
+      console.log(response.data)
       localStorage.setItem("token", response.data.token);
       if (response.data.user?.name) {
         localStorage.setItem("userName", response.data.user.name);
@@ -42,6 +43,11 @@ const Login = () => {
       navigate("/profile");
     } catch (err) {
       const errorMessage = err.response?.data?.error || "Email and password do not match.";
+      console.log(err.response?.data?.error);
+      if(err.response?.data?.error === "User is not confirmed.") {
+        
+        navigate("/confirm", {state: {email}})
+      }
         setErrors(prev => ({...prev, password: errorMessage}));
       
       // alert("Login failed: " + (err.response?.data?.error || "Unknown error"));

--- a/client/src/pages/SignUp.jsx
+++ b/client/src/pages/SignUp.jsx
@@ -68,39 +68,21 @@ const SignUp = () => {
     setLoading(true);
     try {
       await signup({ email, password, name });
-      setShowConfirm(true);
+      //setShowConfirm(true);
+      navigate("/confirm", {state: {email}});
     } catch (err) {
       
     }
     setLoading(false);
   };
 
-  const handleConfirm = async (e) => {
-    e.preventDefault();
-    setLoading(true);
-    try {
-      const response = await confirmEmail({ email, code: confirmCode });
-      alert(response.data.message);
-      navigate("/login");
-    } catch (err) {
-      // alert("Confirmation failed: " + (err.response?.data?.error || "Unknown error"));
-      setErrors((prevErrors) => ({
-        ...prevErrors,
-        confirm: "Invalid confirmation code",
-      }));
-    }
-    setLoading(false);
-  };
-  
   return (
     <div className="signup-page">
       {/* Left Half with Sign-Up Form */}
       <div className="signup-form">
         <div className="signup-form-content">
-          {!showConfirm && <img src={signUp} alt="Picture of a form with two textfields and submit button." className="signup-svg"></img>}
-          {!showConfirm && <h1>Create an Account</h1>}
-          {!showConfirm ? (
-          <>
+          <img src={signUp} alt="Picture of a form with two textfields and submit button." className="signup-svg"></img>
+          <h1>Create an Account</h1>
             <form onSubmit={handleSignUp} noValidate>
               <div>
                 <TextField
@@ -197,71 +179,6 @@ const SignUp = () => {
                 {loading ? "Signing Up..." : "Sign Up"}
               </Button>
             </form>
-          </>
-        ) : (
-          <>
-            <h1>Confirm Your Email</h1>
-            <img src={confirmationImage} alt = "Girl holding a phone with a checkmark icon indicating email confirmation." className="confirmation-svg"></img>
-            <form onSubmit={handleConfirm} noValidate>
-              <div>
-                <TextField
-                  label="Email"
-                  type="email"
-                  variant="outlined"
-                  fullWidth
-                  value={email}
-                  disabled
-                  margin="normal"
-                  slotProps={{
-                    root: {
-                      className: 'form-textfield-root',
-                    },
-                    inputLabel: {
-                      className: 'form-textfield-label',
-                    },
-                    input: {
-                      className:'form-textfield-input',
-                    },
-                  }}
-                />
-              </div>
-              <div>
-                <TextField
-                  label="Confirmation Code"
-                  variant="outlined"
-                  fullWidth
-                  value={confirmCode}
-                  onChange={(e) => setConfirmCode(e.target.value)}
-                  error = {!!errors.confirm}
-                  helperText={errors.confirm}
-                  required
-                  margin="normal"
-                  slotProps={{
-                    root: {
-                      className: 'form-textfield-root',
-                    },
-                    inputLabel: {
-                      className: 'form-textfield-label',
-                    },
-                    input: {
-                      className:'form-textfield-input',
-                    },
-                  }}
-            />
-              </div>
-              <Button
-                type="submit"
-                variant="contained"
-                color="primary"
-                fullWidth
-                className = "signup"
-                disabled={loading}
-              >
-                {loading ? "Confirming..." : "Confirm Email"}
-              </Button>
-            </form>
-          </>
-        )}
         <p className="login-redirect">Already have an account?<a href="/login"> Login now</a></p>
       </div>
       </div>


### PR DESCRIPTION
When a user creates an account, they are now directed to a dedicated confirmation email page.

//TODO:
- Fix the redirection after email is confirmed to the login page
- Add signup error when an account already exists
- Add a generate new code on the confirmation page