### PR TITLE
feat: progress page styles + reading tracker

### DIFF
--- a/client/src/components/ProfilePage/ReadingStreak.jsx
+++ b/client/src/components/ProfilePage/ReadingStreak.jsx
@@ -167,7 +167,7 @@ const ReadingStreak = () => {
               </defs>
             </svg>
           </div>
-          <h3 className="streak-title">Reading Streak</h3>
+          <h2 className="streak-title">Reading Streak</h2>
         </div>
         <p className="streak-motivational" role="status" aria-live="polite">
           {getMotivationalMessage(currentStreak)}

--- a/client/src/pages/ProfileSubPages/Progress.jsx
+++ b/client/src/pages/ProfileSubPages/Progress.jsx
@@ -129,11 +129,14 @@ const Progress = () => {
                   role="listitem"
                   aria-label={`${book.volumeInfo.title}, ${percent}% complete`}
                 >
-                  <img
-                    src={book.volumeInfo.imageLinks?.thumbnail || "/default-book.png"}
-                    alt={`Cover of ${book.volumeInfo.title}`}
-                    className="progress-book-image"
-                  />
+                  <div className="left-side">
+                    <img
+                      src={book.volumeInfo.imageLinks?.thumbnail || "/default-book.png"}
+                      alt={`Cover of ${book.volumeInfo.title}`}
+                      className="progress-book-image"
+                    />
+                    </div>
+                    <div className="right-side">
                   <div className="progress-book-info">
                     <h3>{book.volumeInfo.title}</h3>
                     <p>{book.volumeInfo.authors?.join(", ")}</p>
@@ -214,22 +217,22 @@ const Progress = () => {
                           <span aria-label={`Page ${p.currentPage} of ${totalPages || "unknown"}`}>
                             Page: {p.currentPage} / {totalPages || "?"}
                           </span>
-                          <button
-                            className="progress-edit-btn"
-                            onClick={() => handleEditClick(idx, p.currentPage)}
-                            aria-label={`Update progress for ${book.volumeInfo.title}`}
-                          >
-                            Update
-                          </button>
                         </>
                       )}
                     </div>
-
+                    <button
+                        className="progress-edit-btn"
+                        onClick={() => handleEditClick(idx, p.currentPage)}
+                        aria-label={`Update progress for ${book.volumeInfo.title}`}
+                    >
+                    Update
+                    </button>
                     <div className="progress-percent" aria-hidden="true">
                       {percent}% complete
                     </div>
                   </div>
-                </div>
+                  </div>
+                  </div>
               );
             })
           )}

--- a/client/src/styles/ProfilePage/Progress.css
+++ b/client/src/styles/ProfilePage/Progress.css
@@ -1,11 +1,9 @@
 .progress-page {
   padding: 40px 32px 32px 32px;
-  padding: 40px 32px 32px 32px;
-  background: #ffffff;
+  background-color: var(--background-color);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
   align-items: center;
 }
 
@@ -24,14 +22,14 @@
   flex-direction: column;
   align-items: center;
   width: 100%;
-  padding: 90px 32px 32px 32px;
-  background: #fff;
+  padding: 90px;
+  background-color: var(--background-color);
   gap: 24px;
 }
 
 .progress-title {
   font-size: 2.5rem;
-  color: var(--primary-color);
+  color: var(--text-color);
   font-weight: 700;
   margin: 0;
   text-align: center;
@@ -39,7 +37,7 @@
 
 .progress-streak-wrapper {
   width: 100%;
-  max-width: 680px;
+  max-width: 800px;
   display: flex;
   justify-content: center;
 }
@@ -53,37 +51,42 @@
   flex-direction: column;
   align-items: center;
   gap: 8px;
+  font-size: 1.17em;
 }
 
 .progress-stat-line {
   font-size: 1.2rem;
-  color: #444;
+  color: var(--text-color);
   font-weight: 500;
 }
 
 /* ── Book cards grid ── */
 .progress-list {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 32px;
-  max-width: 900px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 40px;
   margin: 0 auto;
+  align-items: stretch;
 }
 
 .progress-book-card {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-  background: #fff;
-  border-radius: 10px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-  padding: 24px;
   width: 100%;
-  min-width: 0;
-  max-width: 700px;
+  height: 100%;
+  gap: 50px;
+  padding: 30px;
+  background-color: white;
+  border-radius: 10px;
+  align-items: stretch; 
   box-sizing: border-box;
+  align-items: center;
+  max-width: 420px;
 }
+
+:root[data-theme="dark"] .progress-book-card {
+  background-color: var(--filter-pane);
+}
+
 
 /*
   Book image — do NOT force a fixed square size.
@@ -91,12 +94,11 @@
   the natural aspect ratio of book covers.
 */
 .progress-book-image {
-  max-width: 180px;
-  width: 100%;
+  width: 150px;
   height: auto;
   object-fit: contain;
   border-radius: 6px;
-  background: #eee;
+  
 }
 
 .progress-book-card:hover {
@@ -106,12 +108,50 @@
   z-index: 2;
 }
 
-.progress-book-info {
-  flex: 1 1 0;
-  min-width: 0;
-  text-align: center;
+:root[data-theme="dark"] .progress-book-card:hover {
+  box-shadow: 0 4px 12px rgba(222, 212, 242, 0.5);
+}
+.left-side {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
+.right-side {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  justify-content: space-between;
+  text-align: left;
+  width: 100%;
+
+}
+.progress-book-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.progress-book-info h3 {
+  font-weight: 600;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.progress-book-info h3 {
+  color: var(--text-color);
+}
+
+.progress-book-info p {
+  color: var(--secondary-color);
+}
+
+.progress-book-info span {
+  color: var(--text-color);
+}
 .progress-bar-container {
   width: 100%;
   height: 12px;
@@ -123,9 +163,11 @@
 
 .progress-bar {
   height: 100%;
-  background: #ab7ce7;
+  background: var(--primary-color);
   border-radius: 6px 0 0 6px;
+  width: 0%;
   transition: width 0.3s;
+  
 }
 
 .progress-inputs {
@@ -135,6 +177,7 @@
   gap: 8px;
   flex-wrap: nowrap;
   min-width: 0;
+  /* flex-direction: column; */
 }
 
 .progress-inputs label,
@@ -162,21 +205,44 @@
 .progress-edit-btn,
 .progress-save-btn,
 .progress-cancel-btn {
-  background-color: #ab7ce7;
+  background-color: var(--primary-color);
   color: white;
   border: 2px solid #ab7ce7;
   padding: 4px 12px;
-  border-radius: 4px;
+  border-radius: 999px;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 16px;
   transition: all 0.3s ease;
+  margin-top: 15px;
+  margin-bottom: 15px;
+  width: fit-content;
+}
+
+.progress-edit-btn {
+  padding: 10px 20px 10px 20px;
+}
+
+.progress-edit-btn:hover {
+  scale: 1.07;
+}
+
+:root[data-theme="dark"] .progress-edit-btn {
+  color: var(--background-color);
+}
+
+:root[data-theme="dark"] .progress-edit-btn:hover {
+  color: var(--background-color);
+}
+
+:root[data-theme="dark"] .progress-inputs label {
+  color: var(--text-color);
 }
 
 .progress-edit-btn:hover,
 .progress-save-btn:hover {
-  background-color: #f4f4f4;
-  color: #333;
-  border: 2px solid #8561b4;
+  background-color: var(--text-color);
+  color: white;
+  
 }
 
 .progress-cancel-btn {
@@ -193,11 +259,16 @@
 
 .progress-percent {
   font-size: 0.95rem;
-  color: #8561b4;
+  color: var(--text-color);
   font-weight: 600;
-  text-align: center;
+  
 }
 
+@media (min-width: 900px) and (max-width: 1200px) {
+  .progress-list {
+    grid-template-columns: repeat(2, 1fr)
+  }
+}
 /* ── Responsive: tablet ── */
 @media (max-width: 900px) {
   .progress-list {
@@ -251,7 +322,7 @@
   }
 
   .progress-stat-line {
-    font-size: 1rem;
+    font-size: 18px;
   }
 
   .profile-vertical-navbar {

--- a/client/src/styles/ProfilePage/ReadingStreak.css
+++ b/client/src/styles/ProfilePage/ReadingStreak.css
@@ -4,7 +4,7 @@
 
 .streak-container {
   width: 100%;
-  max-width: 680px;
+  max-width: 800px;
   margin: 0 auto 24px auto;
   background: #fff;
   border-radius: 12px;
@@ -12,6 +12,10 @@
   padding: 20px 24px;
   font-family: "Sen", Arial, Helvetica, sans-serif;
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.04);
+}
+
+:root[data-theme="dark"] .streak-container {
+  background-color: var(--filter-pane);
 }
 
 /* --- Header --- */
@@ -54,13 +58,13 @@
 .streak-title {
   font-size: 1.15rem;
   font-weight: 600;
-  color: var(--primary-color, #222);
+  color: var(--text-color);
   margin: 0;
   font-family: inherit;
 }
 
 .streak-motivational {
-  font-size: 0.85rem;
+  font-size: 0.90rem;
   color: var(--secondary-color, #666);
   margin: 0;
   line-height: 1.4;
@@ -107,7 +111,7 @@
 }
 
 .streak-stat__label {
-  font-size: 0.7rem;
+  font-size: 0.8rem;
   color: var(--secondary-color, #666);
   font-weight: 500;
   text-transform: uppercase;
@@ -128,9 +132,9 @@
 }
 
 .streak-heatmap-title {
-  font-size: 0.85rem;
+  font-size: 20px;
   font-weight: 600;
-  color: var(--primary-color, #222);
+  color: var(--text-color, #222);
   margin: 0 0 10px 0;
   text-align: center;
 }
@@ -152,8 +156,20 @@
 /* Month labels row — uses flex to align with week columns */
 .streak-heatmap-months {
   display: flex;
-  gap: 2px;
+  gap: 5px;
   margin-bottom: 3px;
+}
+
+:root[data-theme="dark"] .streak-heatmap-month-slot {
+  color: var(--text-color);
+}
+
+:root[data-theme="dark"] .streak-heatmap-day-labels span {
+  color: var(--text-color);
+}
+
+:root[data-theme="dark"] .streak-heatmap-legend-text {
+  color: var(--text-color);
 }
 
 .streak-heatmap-day-labels-spacer {
@@ -164,8 +180,8 @@
 .streak-heatmap-month-slot {
   width: 11px;
   flex-shrink: 0;
-  font-size: 0.6rem;
-  color: #888;
+  font-size: 15px;
+  color: #585858;
   white-space: nowrap;
   overflow: visible;
 }
@@ -188,8 +204,8 @@
 
 .streak-heatmap-day-labels span {
   height: 11px;
-  font-size: 0.55rem;
-  color: #999;
+  font-size: 15px;
+  color: #585858;
   display: flex;
   align-items: center;
   line-height: 1;
@@ -208,11 +224,15 @@
 }
 
 .streak-heatmap-cell {
-  width: 11px;
-  height: 11px;
+  width: 25px;
+  height: 25px;
   border-radius: 2px;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   cursor: default;
+}
+
+:root[data-theme="dark"] .streak-heatmap-cell--inactive {
+  background: var(--background-color);
 }
 
 .streak-heatmap-cell:focus-visible {
@@ -258,12 +278,12 @@
 }
 
 .streak-heatmap-legend .streak-heatmap-cell {
-  width: 9px;
-  height: 9px;
+  width: 13px;
+  height: 13px;
 }
 
 .streak-heatmap-legend-text {
-  font-size: 0.6rem;
+  font-size: 13px;
   color: #999;
   margin: 0 3px;
 }
@@ -309,6 +329,10 @@
   border: 1px solid #d4e8ff;
 }
 
+:root[data-theme="dark"] .streak-freeze-section {
+  background-color: #243141;
+
+}
 .streak-freeze-info {
   display: flex;
   align-items: center;
@@ -322,14 +346,14 @@
 }
 
 .streak-freeze-title {
-  font-size: 0.8rem;
+  font-size: 16px;
   font-weight: 600;
-  color: var(--primary-color, #222);
+  color: var(--text-color, #222);
   margin: 0;
 }
 
 .streak-freeze-desc {
-  font-size: 0.7rem;
+  font-size: 13px;
   color: var(--secondary-color, #666);
   margin: 1px 0 0 0;
 }
@@ -337,10 +361,10 @@
 .streak-freeze-btn {
   padding: 6px 14px;
   background: #4A9FD6;
-  color: #fff;
+  color: #000000;
   border: none;
   border-radius: 6px;
-  font-size: 0.75rem;
+  font-size: 14px;
   font-weight: 600;
   font-family: "Sen", Arial, Helvetica, sans-serif;
   cursor: pointer;
@@ -420,11 +444,11 @@
   }
 
   .streak-title {
-    font-size: 1rem;
+    font-size: 20px;
   }
 
   .streak-motivational {
-    font-size: 0.78rem;
+    font-size: 15px;
     padding-left: 0;
   }
 
@@ -438,7 +462,7 @@
   }
 
   .streak-stat__label {
-    font-size: 0.6rem;
+    font-size: 11px;
   }
 
   .streak-stat-divider {
@@ -446,8 +470,8 @@
   }
 
   .streak-heatmap-cell {
-    width: 9px;
-    height: 9px;
+    width: 15px;
+    height: 15px;
   }
 
   .streak-heatmap-cells {


### PR DESCRIPTION
added accessible styles to the reading tracker by adjusting font sizes + grid size

edited styles for the books that are in progress to be a grid and show up side by side

edited styles depending on dark/light mode

//FIX:
heatmap month labels don't correctly correspond to the correct cells depending on their month