### PR TITLE
fix: footer overflow + links on signup/login

### DIFF
--- a/client/src/components/LandingPage/Footer.jsx
+++ b/client/src/components/LandingPage/Footer.jsx
@@ -6,7 +6,8 @@ import FavoriteIcon from '@mui/icons-material/Favorite';
 const Footer = () => {
     const location = useLocation();
     const hiddenRoute = ["/login", "/signup", "/confirm"];
-
+    const token = localStorage.getItem("token") //check to see if user is logged in
+    const isAuthenticated = !!token; //true -> user is logged in. false -> user is not logged in
     if (hiddenRoute.includes(location.pathname)) {
         return null;
     }
@@ -31,12 +32,20 @@ const Footer = () => {
                             <li><a className="footer-links" href="/about#mission">Our Mission</a></li>
                             <li><a className="footer-links" href="/about#what-we-offer">What We Offer</a></li>
                         </ul>
-                        <ul className="profile-section"><span className="footer-header">Profile</span>
-                            <li><a className="footer-links" href="/profile"> My Profile</a></li>
-                            <li><a className="footer-links" href="/progress">Book Progress</a></li>
-                            <li><a className="footer-links desktop-only" href="/reviews">Reviews</a></li>
-                            <li><a className="footer-links desktop-only" href="/friends">Friends</a></li>
-                        </ul>
+                        {isAuthenticated ? (
+                            <ul className="profile-section"><span className="footer-header">Profile</span>
+                                <li><a className="footer-links" href="/profile"> My Profile</a></li>
+                                <li><a className="footer-links" href="/progress">Book Progress</a></li>
+                                <li><a className="footer-links desktop-only" href="/reviews">Reviews</a></li>
+                                <li><a className="footer-links desktop-only" href="/friends">Friends</a></li>
+                            </ul>
+                        ) : (
+                            <ul className="profile-section"><span className="footer-header">Profile</span>
+                                <li><a className="footer-links" href="/signup">Sign Up</a></li>
+                                <li><a className="footer-links" href="/login">Login</a></li>
+                                
+                            </ul>
+                        )}
                         <ul className="support-section"><span className="footer-header">Support</span>
                             <li><a className="footer-links" href="/privacyPolicy">Privacy Policy</a></li>
                             <li><a className="footer-links" href="/account">Account</a></li>

--- a/client/src/styles/LandingPage/Footer.css
+++ b/client/src/styles/LandingPage/Footer.css
@@ -129,28 +129,30 @@ footer {
     .team-info {
         flex-direction: column;
         justify-content: center;
-        /* width: 450px; */
         width: 100%;
         max-width: 450px;
     }
 
     .nav-sections {
-        gap: 25px;
-        /* width: 450px; */
+        /* gap: 12px; */
         width: 100%;
         max-width: 450px;
+        flex-wrap: wrap;
+        
     }
 
     .content-wrapper {
         flex-direction: column;
         gap: 20px;
-        align-items: center;
         text-align: left;
+        align-items: center;
     }
 
     .discover-section, .about-us-section, .profile-section, .support-section {
+        padding-left: 0;
         gap: 5px;
     }
+    
 }
 
 @media (min-width: 768px) and (max-width: 1200px) {
@@ -163,10 +165,6 @@ footer {
 
     .footer-header {
         margin-bottom: 0;
-    }
-
-    .nav-sections {
-        gap: 25px;
     }
 
     .desktop-only {


### PR DESCRIPTION
footer no longer overflows on certain screen sizes. flex-wrap avoids this to just add the links to the next line.

profile links were displaying when the user wasn't signed in. now displays certain links depending on if the user is signed in or not.