### PR TITLE
fix: navbar hover on mobile + scroll to sections

### DIFF
--- a/client/src/components/LandingPage/Navbar.jsx
+++ b/client/src/components/LandingPage/Navbar.jsx
@@ -3,7 +3,6 @@ import { useEffect, useRef } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import "../../styles/LandingPage/Navbar.css";
 import MenuIcon from "@mui/icons-material/Menu";
-import CloseIcon from "@mui/icons-material/Close";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import { IconButton } from "@mui/material";
@@ -89,16 +88,18 @@ const Navbar = () => {
     if (window.location.pathname !== "/about") {
       //check the current page location
       navigate(`/about${hash || ""}`); //if the user isnt on the about page already, navigate them there with React Router's navigate
-    } else {
-      if (!hash) {
-        window.scrollTo({ top: 0, behavior: "smooth" });
-        return;
-      }
-      const element = document.querySelector(hash); //if user is already on about
-      if (element) {
-        //scroll smoothly to that section
-        element.scrollIntoView({ behavior: "smooth" });
-      }
+      return;
+    }
+
+    if(!hash) { //if the user is already on the about page
+      window.scrollTo({top: 0, behavior: "smooth"});
+      return;
+    }
+
+    //scroll to the specific dropdown sections in the navbar
+    const element = document.querySelector(hash);
+    if(element) {
+      element.scrollIntoView({behavior: "smooth"});
     }
   };
 
@@ -145,6 +146,7 @@ const Navbar = () => {
                 <Link
                   id="about-dropdown"
                   className={`link ${scrolled ? "link-scrolled" : "not-scroll"}`}
+                  onClick={() => scrollToSection()}
                   to="/about"
                 >
                   About
@@ -449,7 +451,7 @@ const Navbar = () => {
                 </div>
                 <button
                   onClick={handleSignOut}
-                  className={`auth-signout ${scrolled ? "signout-nav" : "not-scroll"}`}
+                  className={`auth-signout desktop-dropdown ${scrolled ? "signout-nav" : "not-scroll"}`}
                 >
                   Sign Out
                 </button>

--- a/client/src/styles/LandingPage/Navbar.css
+++ b/client/src/styles/LandingPage/Navbar.css
@@ -242,6 +242,7 @@ li {
 
 .auth-signout.not-scroll, .auth-signout.signout-nav {
   margin: 0;
+  border: none;
 }
 
 .signout-nav {
@@ -376,12 +377,16 @@ li {
 }
 
 
-@media (hover:none) and (pointer: coarse) {
+/* @media (hover:none) and (pointer: coarse) {
   .about-arrow:hover .dropdown-links, .profile-arrow:hover .dropdown-links {
-    display: none;
+    display: none !important;
   }
-}
+} */
 @media (min-width:300px) and (max-width: 860px) {
+  .about-arrow:hover .dropdown-links, .profile-arrow:hover .dropdown-links {
+    display: none !important;
+  }
+
   .desktop-dropdown {
     display: none;
   }
@@ -555,15 +560,18 @@ li {
 @media (min-width: 860px) and (max-width: 1000px) {
 
   .left {
-    gap: 15px;
+    gap: 25px;
   }
 
   .logged-in {
-    gap: 5px;
+    gap: 10px;
   }
 
   .auth-signout.not-scroll {
     padding: 0;
-    padding: 5px 15px 5px 15px;
+  }
+
+  .auth-signout.desktop-dropdown.not-scroll {
+    padding: 10px 20px;
   }
 }


### PR DESCRIPTION
hovering/clicking over about and profile on mobile no longer shows the desktop dropdown.

on the about page, if you click on the about link again it will take you to the very top of the page for better UI/UX.