### PR TITLE
feat: added high res images + dark mode fix

### DIFF
--- a/client/src/components/SearchPage/BookCard.jsx
+++ b/client/src/components/SearchPage/BookCard.jsx
@@ -9,12 +9,18 @@ const BookCard = ({ info, volumeId }) => {
   const [showFullTitle, setShowFullTitle] = useState(false);
   const [bookshelf, setBookshelf] = useState([]);
 
+  const cover = `https://books.google.com/books/content/images/frontcover/${volumeId}?fife=w400-h600&source=gbs_api`;
+  const fallback = info.imageLinks?.thumbnail ||
+  info.imageLinks?.smallThumbnail ||
+  "/default-book.png";
+
   const email = localStorage.getItem("userEmail");
   const navigate = useNavigate();
 
   const title = info.title || "No Title Available";
   const titleWords = title.split(" ");
   const isLongTitle = titleWords.length > 8;
+  
   const shortTitle = isLongTitle
     ? titleWords.slice(0, 8).join(" ") + "..."
     : title;
@@ -59,7 +65,10 @@ const BookCard = ({ info, volumeId }) => {
       role="button"
     >
       <img
-        src={info.imageLinks?.thumbnail || "/default-book.png"}
+        src={cover}
+        onError={(e) => {
+          e.target.src = fallback;
+        }}
         alt={title}
         className="search-book-image"
       />

--- a/client/src/styles/SearchPage/BookCard.css
+++ b/client/src/styles/SearchPage/BookCard.css
@@ -35,13 +35,14 @@
   gap: 4px;
   width: 100%;
   flex: 1;
+  
 }
 
 .search-book-title {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text-color);
-  text-align: left;
+  text-align: center;
   margin: 0;
   line-height: 1.3;
 }
@@ -62,7 +63,7 @@
 .search-book-authors {
   font-size: 0.85rem;
   color: var(--secondary-color);
-  text-align: left;
+  text-align: center;
   margin: 0 0 12px 0;
   line-height: 1.3;
 }

--- a/client/src/styles/SearchPage/Search.css
+++ b/client/src/styles/SearchPage/Search.css
@@ -302,6 +302,11 @@
     position: relative;
     z-index: 1;
   }
+
+  :root[data-theme="dark"] .filter-toggle-btn {
+    background-color: var(--filter-pane);
+    
+  }
   /* instead of a vertical nav bar, the pane now reveals a modal with the corresponding book filters */
   .filter-pane {
     position: fixed;


### PR DESCRIPTION
manually creating URL to display book covers using volumeId to get high res images for some books (doesn't work for all due to the API)

fixed dark mode style on filter button on mobile

centering book title + author in book card