### PR TITLE
Arrow padding fix

### DIFF
--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -590,6 +590,9 @@ const Profile = () => {
               <button
                 className="scroll-btn right"
                 onClick={() => changeProfileBadge(1)}
+                style={{
+                  right: groupedBadges.length > 2 ? "-35px" : "-16px"
+                }}
               >
                 &#8250;
               </button>


### PR DESCRIPTION
Fixed the padding so arrows do not go over containers when there are more than 2 and so they are not too far when there are 2 containers.