### PR TITLE
Fix book updates

### DIFF
--- a/client/src/pages/FriendProfile.jsx
+++ b/client/src/pages/FriendProfile.jsx
@@ -207,7 +207,7 @@ const FriendProfile = () => {
 
   const handleAddToLibrary = async (bookId) => {
     try {
-      await addBookToBookshelf({ email: currentUserEmail, bookId });
+      await addBookToBookshelf({ email: currentUserEmail, volumeId: bookId });
       setUserBookshelf((prev) => [...prev, bookId]);
     } catch (e) {}
   };


### PR DESCRIPTION
When user adds a book from their friends list to bookshelf, it now correctly passes in the volumeId and reflects on their page.